### PR TITLE
prototypes.controller#create変更

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -12,7 +12,8 @@ class PrototypesController < ApplicationController
 	end
 
 	def create
-  	if @prototype = Prototype.create(prototype_params)
+		@prototype = Prototype.new(prototype_params)
+  	if @prototype.save
 			redirect_to root_path
 		else
 			render :new


### PR DESCRIPTION
# what
createアクションの定義の変更

# why
元のcodeでは、うまくrennderが機能しない。
未保存時のnewページ遷移バグの修正のため
